### PR TITLE
setup.py: adjust packages value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='djangohelpers',
       author_email='ctl-dev@columbia.edu',
       url='https://github.com/ccnmtl/djangohelpers',
       license='BSD',
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+      packages=find_packages(include=['djangohelpers', 'djangohelpers.*']),
       include_package_data=True,
       zip_safe=False,
       install_requires=[


### PR DESCRIPTION
Use find_packages() to include our package names. The 0.24 may be having some trouble with this.

https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#packages